### PR TITLE
fix WordCount makefile

### DIFF
--- a/WindFlow/WordCount/Makefile
+++ b/WindFlow/WordCount/Makefile
@@ -1,11 +1,14 @@
 # Author: Gabriele Mencagli
 # Date: 11/01/2020
 
-all:
+all: bin
 	$(MAKE) -C src
 
 clean:
-	$(MAKE) clean -C src
+	$(RM) -r bin && $(MAKE) clean -C src
+
+bin:
+	@mkdir -p bin
 
 .DEFAULT_GOAL := all
 .PHONY: all clean

--- a/WindFlow/WordCount/src/Makefile
+++ b/WindFlow/WordCount/src/Makefile
@@ -8,7 +8,7 @@ OUT_DIR			= ../bin
 
 CXX 			= g++
 CXXFLAGS		= -std=c++17
-INCLUDES		= -I $(FF_ROOT) -I $(WF_INCLUDES) -I $(INCLUDE_DIR)
+INCLUDES		+= -I $(FF_ROOT) -I $(WF_INCLUDES) -I $(INCLUDE_DIR)
 MACRO           = -DFF_BOUNDED_BUFFER -DDEFAULT_BUFFER_CAPACITY=32786 -DNDEBUG
 OPTFLAGS		= -g -O3 -finline-functions
 LDFLAGS			= -pthread


### PR DESCRIPTION
Two main modifications:
- create and delete bin folder
- allow supplying of different include folders during make command, eg. `INCLUDES="-I ~/.local/include" make`